### PR TITLE
Render appropriate post action in feed

### DIFF
--- a/app/helpers/feeds_helper.rb
+++ b/app/helpers/feeds_helper.rb
@@ -1,0 +1,34 @@
+module FeedsHelper
+
+  def write_post_action post
+
+    # render form
+    if @current_user && @current_user.confirmed_registration
+      render :partial => "posts/form", locals: {post: post}
+
+    # render confirmation reminder
+    elsif @current_user
+      render :partial => "shared/notice",
+        locals: {
+          notice: {
+            :path => confirmation_reminder_registration_path,
+            :icon => "email",
+            :text => "Please confirm your email address to create a new post."
+          }
+        }
+
+    # render log in notice
+    else
+      render :partial => "shared/notice",
+        locals: {
+          notice: {
+            :path => login_path,
+            :icon => "vpn_key",
+            :text => "Please log in or sign up to create a new post."
+          }
+        }
+
+    end
+  end
+
+end

--- a/app/views/feeds/show.html.erb
+++ b/app/views/feeds/show.html.erb
@@ -1,5 +1,5 @@
 <h1>Conversations</h1>
 
-<%= render :partial => "posts/form", locals: {post: @post} %>
+<%= write_post_action @post %>
 
 <%= render(@posts) || "There are no posts to show. Why don't you write one to get started?" %>

--- a/app/views/shared/_notice.html.erb
+++ b/app/views/shared/_notice.html.erb
@@ -1,0 +1,18 @@
+<div class="notice">
+  <%= link_to notice[:path] do %>
+    <div class="row">
+      <div class="col s12">
+        <div class="section z-depth-3 blue darken-2 white-text">
+          <div class="row no_margin_bottom">
+            <div class="col s3 m2 l1 center-align">
+              <%= material_icon.send(notice[:icon]).md_48 %>
+            </div>
+            <div class="col s9 m10 l11 left-align">
+              <p><%= notice[:text] %></p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  <% end %>
+</div>

--- a/spec/views/feeds/show.html.erb_spec.rb
+++ b/spec/views/feeds/show.html.erb_spec.rb
@@ -14,11 +14,34 @@ RSpec.describe "feeds/show.html.erb", type: :view do
    expect(rendered).to have_selector("h1", text: "Conversations")
   end
 
-  it "has a form for creating a new post" do
-   assign(:posts, Post.none)
-   render
+  context "when user is signed in and confirmed" do
+    it "has a form for creating a new post" do
+     assign(:posts, Post.none)
+     assign(:current_user, build_stubbed(:user))
+     render
 
-   expect(rendered).to have_selector("form", text: "Post")
+     expect(rendered).to have_selector("form", text: "Post")
+    end
+  end
+
+  context "when user is signed in but not confirmed" do
+    it "shows a message to confirm email address" do
+     assign(:posts, Post.none)
+     assign(:current_user, build_stubbed(:user, :confirmed_registration => false))
+     render
+
+     expect(rendered).to have_selector("div.notice", text: "Please confirm your email address to create a new post")
+    end
+  end
+
+  context "when user is not signed in" do
+    it "shows a message to confirm email address" do
+     assign(:posts, Post.none)
+     assign(:current_user, nil)
+     render
+
+     expect(rendered).to have_selector("div.notice", text: "Please log in or sign up to create a new post")
+    end
   end
 
   context "when there are posts to show" do


### PR DESCRIPTION
Render form or notice depending on whether user is signed in, confirmed, or
logged out.
